### PR TITLE
Zoning In liquid Z fixes.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1512,9 +1512,12 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	{
 		// This prevents hopping on logging in.
 		glm::vec3 loc(sze->player.spawn.x,sze->player.spawn.y,sze->player.spawn.z);
-		m_Position.z = zone->zonemap->FindBestZ(loc, nullptr);
-		if(size > 0)
-			m_Position.z += static_cast<int16>(size);
+		if (!zone->watermap->InLiquid(loc))
+		{
+			m_Position.z = zone->zonemap->FindBestZ(loc, nullptr);
+			if(size > 0)
+				m_Position.z += static_cast<int16>(size);
+		}
 
 		sze->player.spawn.z = m_Position.z;
 	}


### PR DESCRIPTION
Zoning in liquid, will no longer correct z for bestz.  This fixes qcat zoning issues.