### PR TITLE
Bug fixes.  Silk wearing mitigation boost.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -631,7 +631,7 @@ void Mob::MeleeMitigation(Mob *attacker, int32 &damage, int32 minhit, ExtraAttac
 
 		if (GetClass() == WIZARD || GetClass() == MAGICIAN ||
 				GetClass() == NECROMANCER || GetClass() == ENCHANTER)
-			mitigation_rating = ((GetSkill(SkillDefense) + itembonuses.HeroicAGI/10) / 4.0) + armor + 1;
+			mitigation_rating = ((GetSkill(SkillDefense) + itembonuses.HeroicAGI/10) / 2.0) + armor + 1;
 		else
 			mitigation_rating = ((GetSkill(SkillDefense) + itembonuses.HeroicAGI/10) / 3.0) + (armor * 1.333333) + 1;
 		mitigation_rating *= 0.847;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5426,7 +5426,7 @@ void Client::Handle_OP_MoveItem(const EQApplicationPacket *app)
 	MoveItem_Struct* mi = (MoveItem_Struct*)app->pBuffer;
 	Log.Out(Logs::Detail, Logs::Inventory, "Moveitem from_slot: %i, to_slot: %i, number_in_stack: %i", mi->from_slot, mi->to_slot, mi->number_in_stack);
 
-	if (spellend_timer.Enabled() && casting_spell_id && !IsBardSong(casting_spell_id))
+	if (spellend_timer.Enabled() && casting_spell_id && !IsBardSong(casting_spell_id) && mi->from_slot != MainCursor)
 	{
 		if (mi->from_slot != mi->to_slot && (mi->from_slot <= EmuConstants::GENERAL_END || mi->from_slot > 39) && IsValidSlot(mi->from_slot) && IsValidSlot(mi->to_slot))
 		{

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1112,11 +1112,15 @@ void Client::OPMemorizeSpell(const EQApplicationPacket* app)
 					ScribeSpell(memspell->spell_id, memspell->slot);
 					DeleteItemInInventory(MainCursor, 0, true);
 				}
-				else
-					Message(0,"Scribing spell: inst exists but item does not or spell ids do not match.");
+				else {
+					Message_StringID(MT_Spells, ABORTED_SCRIBING_SPELL);
+					SendSpellBarEnable(0); // if we don't send this, the client locks up
+				}
 			}
-			else
-				Message(0,"Scribing a spell without an inst on your cursor?");
+			else {
+				Message_StringID(MT_Spells, ABORTED_SCRIBING_SPELL);
+				SendSpellBarEnable(0);
+			}
 			break;
 		}
 		case memSpellMemorize:	{	// memming spell

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -363,6 +363,7 @@
 #define NOT_IN_CONTROL				12368	//You do not have control of yourself right now.
 #define TOO_DISTRACTED				12440   //You are too distracted to cast a spell now!
 #define ALREADY_CASTING				12442	//You are already casting a spell!
+#define ABORTED_SCRIBING_SPELL		12044   //Aborting scribing of spell.
 #define SENSE_CORPSE_NOT_NAME		12446	//You don't sense any corpses of that name.
 #define SENSE_CORPSE_NONE			12447	//You don't sense any corpses.
 #define SCREECH_BUFF_BLOCK			12448	//Your immunity buff protected you from the spell %1!


### PR DESCRIPTION
Added a fix for client freezing while scribing a spell and the spell was swapped in inventory for another spell.
Dropping an item into your inventory during casting a spell, will no longer cause an immediate disconnect from the server.  You have been warned.  Stand there and die like the rest of us.
Increased mitigation for silk wearers, based on defense skill.  This is based on formulas provided by SOE on mitigation calculations.