### PR TITLE
Bug fix where charmed mobs can cause faction wars.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1276,6 +1276,21 @@ void EntityList::Save()
 	}
 }
 
+void EntityList::InterruptTargeted(Mob* mob)
+{
+	if (!mob)
+		return;
+	Mob* Cur = nullptr;
+
+	auto it = npc_list.begin();
+	while (it != npc_list.end()) {
+		Cur = it->second;
+		if (Cur->GetTarget() == mob && (!Cur->GetOwner() || !Cur->GetOwner()->IsClient()) && Cur->IsCasting()) 
+			Cur->InterruptSpell();
+		++it;
+	}	
+}
+
 void EntityList::ReplaceWithTarget(Mob *pOldMob, Mob *pNewTarget)
 {
 	if (!pNewTarget)

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -276,6 +276,7 @@ public:
 	void	QuestJournalledSayClose(Mob *sender, Client *QuestIntiator, float dist, const char* mobname, const char* message);
 	void	GroupMessage(uint32 gid, const char *from, const char *message);
 	void	RemoveFromTargets(Mob* mob);
+	void	InterruptTargeted(Mob* mob);
 	void	ReplaceWithTarget(Mob* pOldMob, Mob*pNewTarget);
 	void	QueueCloseClients(Mob* sender, const EQApplicationPacket* app, bool ignore_sender=false, float dist=200, Mob* SkipThisMob = 0, bool ackreq = true,eqFilterType filter=FilterNone);
 	void	QueueCloseClientsSplit(Mob* sender, const EQApplicationPacket* app, const EQApplicationPacket* app2 = nullptr, bool ignore_sender=false, float dist=200, Mob* SkipThisMob = 0, bool ackreq = true,eqFilterType filter=FilterNone);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3787,6 +3787,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses, bool death)
 					// clear the hate list of the mobs
 					entity_list.ReplaceWithTarget(this, tempmob);
 					WipeHateList();
+					entity_list.InterruptTargeted(this);
 					if(tempmob)
 						AddToHateList(tempmob, 1, 0);
 					SendAppearancePacket(AT_Anim, ANIM_STAND);


### PR DESCRIPTION
Any NPCs casting a spell on a charmed NPC, when charm breaks, will now have their spells interrupted.