### PR TITLE
Pathing Tools Improvements.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -7132,8 +7132,11 @@ void command_path(Client *c, const Seperator *sep)
 		{
 			if (sep->arg[2][0] == '\0')
 				return;
-
+			
+			zone->pathing->SortNodes();
+			zone->pathing->ResortConnections();
 			zone->pathing->DumpPath(sep->arg[2]);
+			c->Message(0, "Path file saved as %s", sep->arg[2]);
 		}
 		return;
 	}
@@ -7203,6 +7206,7 @@ void command_path(Client *c, const Seperator *sep)
 			if (zone->pathing->DeleteNode(c))
 			{
 				c->Message(0, "Removed Node.");
+				zone->pathing->CheckNodeErrors(c);
 			}
 			else
 			{
@@ -7298,6 +7302,8 @@ void command_path(Client *c, const Seperator *sep)
 			{
 				zone->pathing->ResortConnections();
 				c->Message(0, "Connections resorted...");
+				c->Message(0, "Spawned Nodes will need respawned to display proper node id.");
+				zone->pathing->CheckNodeErrors(c);
 			}
 		}
 		return;
@@ -7352,13 +7358,16 @@ void command_path(Client *c, const Seperator *sep)
 			if (!strcasecmp(sep->arg[2], "simple"))
 			{
 				c->Message(0, "You may go linkdead. Results will be in the log file.");
-				zone->pathing->SimpleMeshTest();
+				zone->pathing->SimpleMeshTest(c);
 				return;
 			}
-			else
+			else if(!strcasecmp(sep->arg[2], "complex"))
 			{
 				c->Message(0, "You may go linkdead. Results will be in the log file.");
 				zone->pathing->MeshTest();
+				return;
+			} else {
+				c->Message(0, "Usage: #path meshtest [simple|complex] - complex may result in linkdead/zone crash");
 				return;
 			}
 		}

--- a/zone/pathing.h
+++ b/zone/pathing.h
@@ -67,14 +67,16 @@ public:
 	glm::vec3 GetPathNodeCoordinates(int NodeNumber, bool BestZ = true);
 	bool CheckLosFN(glm::vec3 a, glm::vec3 b);
 	void SpawnPathNodes();
+	void SpawnNode(PathNode *node);
 	void MeshTest();
-	void SimpleMeshTest();
+	void SimpleMeshTest(Client *c);
 	int FindNearestPathNode(glm::vec3 Position);
 	bool NoHazards(glm::vec3 From, glm::vec3 To);
 	bool NoHazardsAccurate(glm::vec3 From, glm::vec3 To);
 	void OpenDoors(int Node1, int Node2, Mob* ForWho);
 
 	PathNode* FindPathNodeByCoordinates(float x, float y, float z);
+	PathNode* FindPathNodeById(uint16 nodeid);
 	void ShowPathNodeNeighbours(Client *c);
 	int GetRandomPathNode();
 
@@ -96,6 +98,7 @@ public:
 	void ResortConnections();
 	void QuickConnect(Client *c, bool set = false);
 	void SortNodes();
+	void CheckNodeErrors(Client *c);
 
 private:
 	PathFileHeader Head;


### PR DESCRIPTION
#path meshtest, will now required a 2nd parameter, simple or complex.  Using #path meshtest simple will now feedback information directly to the client.
#path dump <filename> will resort connections and nodes, prior to saving.  This will help prevent saving unsorted pathnodes, which will cause the path to be unusable.
#path move, will move the selected node visibly to your location.  This will also update distances from this node to the neighbors.  And neighbors to this node.  Without the distance update, this would almost always break paths at finding shortest distance paths, if a node was ever moved.
#path remove, will remove the selected node visible in the zone.  You must use #path resort nodes, prior to using the pathing, or the zone will likely crash.  Following removal of the node, a simple check of the nodes will be performed, in order to warn of potential errors.