### PR TITLE
Mob position update optimizations.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1242,6 +1242,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	default:
 		size = 0; base_size = 0;
 	}
+	z_offset = CalcZOffset();
 	/* Initialize AA's : Move to function eventually */
 	for (uint32 a = 0; a < MAX_PP_AA_ARRAY; a++){ aa[a] = &m_pp.aa_array[a]; }
 	query = StringFormat(

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -403,6 +403,8 @@ public:
 	inline const float GetEQHeading() const { return m_EQPosition.w; }
 	inline const float GetSize() const { return size; }
 	inline const float GetBaseSize() const { return base_size; }
+	inline const float GetZOffset() const { return z_offset; }
+	inline const float SetBestZ(float z_coord) const { return z_coord + z_offset; }
 	inline const float GetTarX() const { return m_TargetLocation.x; }
 	inline const float GetTarY() const { return m_TargetLocation.y; }
 	inline const float GetTarZ() const { return m_TargetLocation.z; }
@@ -941,8 +943,7 @@ public:
 	float Tune_CheckHitChance(Mob* defender, Mob* attacker, SkillUseTypes skillinuse, int Hand, int16 chance_mod, int Msg = 1,int acc_override=0, int avoid_override=0, int add_acc=0, int add_avoid = 0);
 	void Tune_FindAccuaryByHitChance(Mob* defender, Mob *attacker, float hit_chance, int interval, int max_loop, int avoid_override, int Msg = 0);
 	void Tune_FindAvoidanceByHitChance(Mob* defender, Mob *attacker, float hit_chance, int interval, int max_loop, int acc_override, int Msg = 0);
-
-	float SetBestZ(float z_coord);
+	float CalcZOffset();
 
 protected:
 	void CommonDamage(Mob* other, int32 &damage, const uint16 spell_id, const SkillUseTypes attack_skill, bool &avoidable, const int8 buffslot, const bool iBuffTic);
@@ -1039,6 +1040,7 @@ protected:
 	uint16 animation;
 	float base_size;
 	float size;
+	float z_offset;
 	float runspeed;
 	float walkspeed;
 	float fearspeed;

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1569,24 +1569,24 @@ void Mob::AI_Process() {
 						//	printf("Pet start pos: (%f, %f, %f)\n", GetX(), GetY(), GetZ());
 
 						float dist = DistanceSquared(m_Position, owner->GetPosition());
-						if (dist >= 400)
+						if ((dist >= 2500 && GetCurrentSpeed() <= 0.0f) || (dist >= 400 && GetCurrentSpeed() > 0.0f))
 						{
-							float speed = GetWalkspeed();
+							float speed = owner->GetWalkspeed();
 							if (dist >= 5625)
 								speed = GetRunspeed();
 							SetCurrentSpeed(speed);
 							if (speed > 0.0f)
 							{
 								if(!zone->pathing) {
-									CalculateNewPosition2(owner->GetX(), owner->GetY(), owner->GetZ(), speed);
+									CalculateNewPosition2(owner->GetX(), owner->GetY(), owner->GetZ() - owner->GetZOffset() + GetZOffset(), speed);
 								} else {
 									bool WaypointChanged, NodeReached;
-									glm::vec3 Goal = UpdatePath(owner->GetX(), owner->GetY(), owner->GetZ(), speed, WaypointChanged, NodeReached);
+									glm::vec3 Goal = UpdatePath(owner->GetX(), owner->GetY(), owner->GetZ() - owner->GetZOffset() + GetZOffset(), speed, WaypointChanged, NodeReached);
 
 									if(WaypointChanged)
 										tar_ndx = 20;
 
-									CalculateNewPosition2(Goal.x, Goal.y, Goal.z, GetRunspeed());
+									CalculateNewPosition2(Goal.x, Goal.y, Goal.z, speed);
 								}
 							}
 						} else if(IsMoving()) {
@@ -1701,6 +1701,7 @@ void NPC::AI_DoMovement() {
 		return;	//this is idle movement at walk speed, and we are unable to walk right now.
 
 	if (roambox_distance > 0) {
+		float roam_z = GetZ();
 		if (
 			roambox_movingto_x > roambox_max_x
 			|| roambox_movingto_x < roambox_min_x
@@ -1728,11 +1729,24 @@ void NPC::AI_DoMovement() {
 				roambox_movingto_x = zone->random.Real(roambox_min_x+1,roambox_max_x-1);
 			if (roambox_movingto_y > roambox_max_y || roambox_movingto_y < roambox_min_y)
 				roambox_movingto_y = zone->random.Real(roambox_min_y+1,roambox_max_y-1);
+
+			if (zone->HasMap()){
+				glm::vec3 dest(roambox_movingto_x, roambox_movingto_y, GetZ());
+
+
+				if (!zone->HasWaterMap() || !zone->watermap->InLiquid(dest)) {
+
+					float newz = zone->zonemap->FindBestZ(dest, nullptr);
+
+					if (newz > -5000)
+						roam_z = SetBestZ(newz);
+				}
+			}
 		}
 
 		Log.Out(Logs::Detail, Logs::AI, "Roam Box: d=%.3f (%.3f->%.3f,%.3f->%.3f): Go To (%.3f,%.3f)",
 			roambox_distance, roambox_min_x, roambox_max_x, roambox_min_y, roambox_max_y, roambox_movingto_x, roambox_movingto_y);
-		if (!CalculateNewPosition2(roambox_movingto_x, roambox_movingto_y, GetZ(), walksp, true))
+		if (!CalculateNewPosition2(roambox_movingto_x, roambox_movingto_y, roam_z, walksp, true))
 		{
 			roambox_movingto_x = roambox_max_x + 1; // force update
 			pLastFightingDelayMoving = Timer::GetCurrentTime() + RandomTimer(roambox_min_delay, roambox_delay);

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -223,7 +223,7 @@ void NPC::UpdateWaypoint(int wp_index)
 
 			float newz = zone->zonemap->FindBestZ(dest, nullptr);
 
-			if ((newz > -2000) && std::abs(newz - dest.z) < RuleR(Map, FixPathingZMaxDeltaWaypoint))
+			if ((newz > -2000) && std::abs(newz + GetZOffset() - dest.z) < (RuleR(Map, FixPathingZMaxDeltaWaypoint) + GetZOffset()))
 			{
 				m_CurrentWayPoint.z = SetBestZ(newz);
 			}
@@ -602,7 +602,7 @@ bool Mob::MakeNewPositionAndSendUpdate(float x, float y, float z, float speed, b
 				Log.Out(Logs::Detail, Logs::AI, "BestZ returned %4.3f at %4.3f, %4.3f, %4.3f", newz,m_Position.x,m_Position.y,m_Position.z);
 
 				if ((newz > -2000) &&
-				    std::abs(newz - dest.z) < RuleR(Map, FixPathingZMaxDeltaMoving)) // Sanity check.
+				    std::abs(newz + GetZOffset() - dest.z) < RuleR(Map, FixPathingZMaxDeltaMoving)) // Sanity check.
 				{
 					if((std::abs(x - m_Position.x) < 0.5) && (std::abs(y - m_Position.y) < 0.5))
 					{
@@ -734,11 +734,11 @@ bool Mob::MakeNewPositionAndSendUpdate(float x, float y, float z, float speed, b
 			Log.Out(Logs::Detail, Logs::AI, "BestZ returned %4.3f at %4.3f, %4.3f, %4.3f", newz,m_Position.x,m_Position.y,m_Position.z);
 
 			if ((newz > -2000) &&
-			    std::abs(newz - dest.z) < RuleR(Map, FixPathingZMaxDeltaMoving)) // Sanity check.
+			    std::abs(newz + GetZOffset() - dest.z) < (RuleR(Map, FixPathingZMaxDeltaMoving) + GetZOffset())) // Sanity check.
 			{
 				if(std::abs(x - m_Position.x) < 0.5 && std::abs(y - m_Position.y) < 0.5)
 				{
-					if(std::abs(z - m_Position.z) <= RuleR(Map, FixPathingZMaxDeltaMoving))
+					if(std::abs(z - m_Position.z) <= (RuleR(Map, FixPathingZMaxDeltaMoving) + GetZOffset()))
 						m_Position.z = z;
 					else
 					{
@@ -890,7 +890,7 @@ bool Mob::CalculateNewPosition(float x, float y, float z, float speed, bool chec
 			Log.Out(Logs::Detail, Logs::AI, "BestZ returned %4.3f at %4.3f, %4.3f, %4.3f", newz,m_Position.x,m_Position.y,m_Position.z);
 
 			if ((newz > -2000) &&
-			    std::abs(newz - dest.z) < RuleR(Map, FixPathingZMaxDeltaMoving)) // Sanity check.
+			    std::abs(newz + GetZOffset() - dest.z) < (RuleR(Map, FixPathingZMaxDeltaMoving) + GetZOffset())) // Sanity check.
 			{
 				if (std::abs(x - m_Position.x) < 0.5 && std::abs(y - m_Position.y) < 0.5)
 				{
@@ -990,7 +990,7 @@ void NPC::AssignWaypoints(int32 grid)
 
 				float newz = zone->zonemap->FindBestZ(dest, nullptr);
 
-				if( (newz > -2000) && std::abs(newz-dest.z) < RuleR(Map, FixPathingZMaxDeltaLoading))
+				if( (newz > -2000) && std::abs(newz+GetZOffset()-dest.z) < (RuleR(Map, FixPathingZMaxDeltaLoading)+GetZOffset()))
 				{
 					newwp.z = SetBestZ(newz);
 				}


### PR DESCRIPTION
Moved z_offset to be precalculated when size is set/changed.
Added z_offset to diff z checks for when z needs adjusted during pathing/moving.  Mobs that are larger size, can be off more, and need adjusted.
Moved pets to walk at their owners walk speed, to make their movement while following smoother.
Pets will now have slightly different distances to when they start to follow their owners and when they catch up.  That way pets are not starting/stopping so much and sending more position update packets.
Pets at a distance will now send their position updates out to everyone less frequently.
When x and y are calculated in a roam box, the z will use the bestz at that location, rather than GetZ().  This helps prevent mobs on the move from bouncing up and down as often.