### PR TITLE
Stationary ground spawns will now visibly re-spawn for a client in the zone.

### DIFF
--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -395,15 +395,10 @@ bool Object::Process(){
 	}
 
 	if(m_ground_spawn && respawn_timer.Check()){
+		RandomSpawn(true);
 		// We only want to check groundspawns that randomly spawn.
-		if(RuleB(Groundspawns, RandomSpawn) && m_min_x != m_max_x && m_min_y != m_max_y)
-		{
-			RandomSpawn(true);
-		}
-		else
-		{
-			respawn_timer.Disable();
-		}
+		if(!RuleB(Groundspawns, RandomSpawn) || m_min_x == m_max_x || m_min_y == m_max_y)
+			respawn_timer.Disable();;
 	}
 	return true;
 }


### PR DESCRIPTION
Stationary ground spawns will now visibly re-spawn for client that is in the zone.  You will no longer have to rezone, for them to appear.