### PR TITLE
Targeting fix.  FD taking Rampage damage fix.  Mob fleeing behavior fix.

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -1100,7 +1100,7 @@ struct CombatDamage_Struct
 /* 04 */	uint8	type; //slashing, etc. 231 (0xE7) for spells
 /* 05 */	uint16	spellid;
 /* 07 */	uint32	damage;
-/* 11 */	float unknown11;
+/* 11 */	float force;
 /* 15 */	float sequence;	// see above notes in Action_Struct
 /* 19 */	uint32	unknown19;
 /* 23 */

--- a/common/patches/mac.cpp
+++ b/common/patches/mac.cpp
@@ -746,8 +746,7 @@ namespace Mac {
 		OUT(type);
 		OUT(spellid);
 		OUT(damage);
-		eq->unknown12 = emu->unknown11;
-		//OUT(unknown11);
+		OUT(force);
 		OUT(sequence);
 		//OUT(unknown19);
 		FINISH_ENCODE();

--- a/common/patches/mac_structs.h
+++ b/common/patches/mac_structs.h
@@ -268,7 +268,7 @@ struct CombatDamage_Struct
 	/*005*/	uint8   unknown;
 	/*006*/	uint16	spellid;
 	/*008*/	int32	damage;
-	/*012*/	float	unknown12;
+	/*012*/	float	force;
 	/*016*/	float	sequence;
 	/*020*/	uint8	unknown20[4];
 	/*024*/

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1946,7 +1946,7 @@ void NPC::Damage(Mob* other, int32 damage, uint16 spell_id, SkillUseTypes attack
 
 	if(damage > 0) {
 		//see if we are gunna start fleeing
-		if(!IsPet()) CheckFlee();
+		if(!IsPet() && !IsCasting()) CheckFlee();
 	}
 }
 
@@ -3569,35 +3569,35 @@ void Mob::CommonDamage(Mob* attacker, int32 &damage, const uint16 spell_id, cons
 			case Skill1HSlashing:
 			case SkillHandtoHand:
 			case SkillThrowing:
-				a->unknown11 = 0.1f;
+				a->force = 0.1f;
 				break;
 			case Skill2HBlunt:
 			case Skill2HSlashing:
 			case SkillEagleStrike:
 			case SkillKick:
-				a->unknown11 = 0.2f;
+				a->force = 0.2f;
 				break;
 			case SkillArchery:
-				a->unknown11 = 0.15f;
+				a->force = 0.15f;
 				break;
 			case SkillBackstab:
 			case SkillBash:
-				a->unknown11 = 0.3f;
+				a->force = 0.3f;
 				break;
 			case SkillDragonPunch:
-				a->unknown11 = 0.25f;
+				a->force = 0.25f;
 				break;
 			case SkillFlyingKick:
-				a->unknown11 = 0.4f;
+				a->force = 0.4f;
 				break;
 			case Skill1HPiercing:
 			case SkillFrenzy:
-				a->unknown11 = 0.05f;
+				a->force = 0.05f;
 				break;
 			default:
-				a->unknown11 = 0.0f;
+				a->force = 0.0f;
 			}
-			if (a->unknown11 > 0.0f)
+			if (a->force> 0.0f)
 				a->sequence = attacker->GetHeading() * 2.0f;
 		}
 		

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -7976,8 +7976,8 @@ void Client::Handle_OP_TargetCommand(const EQApplicationPacket *app)
 					}
 				}
 			}
-			else if (DistanceSquared(m_Position, GetTarget()->GetPosition()) > (zone->newzone_data.maxclip*zone->newzone_data.maxclip))
-			{
+			else if (DistanceSquared(m_Position, GetTarget()->GetPosition()) > (zone->newzone_data.maxclip*zone->newzone_data.maxclip + 2500))
+			{ // client will allow targeting something just beyond max clip just out of sight, so add another 50 for that.
 				char *hacker_str = nullptr;
 				MakeAnyLenString(&hacker_str, "%s attempting to target something beyond the clip plane of %.2f units,"
 					" from (%.2f, %.2f, %.2f) to %s (%.2f, %.2f, %.2f)", GetName(),

--- a/zone/fearpath.cpp
+++ b/zone/fearpath.cpp
@@ -97,7 +97,8 @@ void Mob::CheckFlee() {
 
 void Mob::ProcessFlee()
 {
-
+	if (!flee_mode)
+		return;
 	//Stop fleeing if effect is applied after they start to run.
 	//When ImmuneToFlee effect fades it will turn fear back on and check if it can still flee.
 	if (flee_mode && (GetSpecialAbility(IMMUNE_FLEEING) || spellbonuses.ImmuneToFlee) &&

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1569,7 +1569,7 @@ void Mob::AI_Process() {
 						//	printf("Pet start pos: (%f, %f, %f)\n", GetX(), GetY(), GetZ());
 
 						float dist = DistanceSquared(m_Position, owner->GetPosition());
-						if ((dist >= 2500 && GetCurrentSpeed() <= 0.0f) || (dist >= 400 && GetCurrentSpeed() > 0.0f))
+						if (dist >= 400)
 						{
 							float speed = owner->GetWalkspeed();
 							if (owner->IsClient())
@@ -2281,6 +2281,8 @@ bool Mob::Rampage(ExtraAttackOptions *opts)
 		if (m_target)
 		{
 			if (m_target == GetTarget())
+				continue;
+			if (m_target->IsClient() && m_target->CastToClient()->GetFeigned())
 				continue;
 
 			// Note: Some (most?) rampage NPCs could hit their ramp target from any distance.  Some required a certain


### PR DESCRIPTION
Added a buffer outside range of max clip for targeting.  The client allows targeting just outside of the clip plane, if a mob was right where you clicked.  This will prevent the target from becoming invalid, and causing you to have to re-target the mob to attack.
Removed the delta for pet following that was in last patch.  It did not work very well anyways.
If you FD while on the rampage list, you will no longer get hit.  The rampage will go on to the next person in rampage order.  The FD person will not be removed from the list, so if they get back up, stand by to continue to take rampage.
If a mob is casting a spell, they will not process a flee check until finished casting.  This prevents some abnormal behavior, if that spell was a heal on them, and would have put them above the point to flee.  Now they will stand and fight, so interrupt that healing spell.