### PR TITLE
Simple spell push on clients moved to action packet.

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -850,13 +850,12 @@ struct Action_Struct
  /* 00 */	uint16 target;	// id of target
  /* 02 */	uint16 source;	// id of caster
  /* 04 */	uint16 level; // level of caster
- /* 06 */	uint16 instrument_mod;
- /* 08 */	uint32 bard_focus_id;
- /* 12 */	uint16 unknown16;
+ /* 06 */	uint32 instrument_mod;
+ /* 10 */	float force;
 // some kind of sequence that's the same in both actions
 // as well as the combat damage, to tie em together?
  /* 14 */	float sequence;
- /* 18 */	uint32 unknown18;
+ /* 18 */	float pushup_angle;
  /* 22 */	uint8 type;		// 231 (0xE7) for spells
  /* 23 */	uint32 unknown23;
  /* 27 */	uint16 spell;	// spell id being cast
@@ -878,7 +877,7 @@ struct CombatDamage_Struct
 /* 07 */	uint32	damage;
 /* 11 */	float force;
 /* 15 */	float sequence;	// see above notes in Action_Struct
-/* 19 */	uint32	unknown19;
+/* 19 */	float pushup_angle; // associated with force.  Sine of this angle, multiplied by force, will be z push.
 /* 23 */
 };
 

--- a/common/patches/mac.cpp
+++ b/common/patches/mac.cpp
@@ -748,7 +748,7 @@ namespace Mac {
 		OUT(damage);
 		OUT(force);
 		OUT(sequence);
-		//OUT(unknown19);
+		OUT(pushup_angle);
 		FINISH_ENCODE();
 	}
 
@@ -762,8 +762,9 @@ namespace Mac {
 		OUT(level);
 		eq->unknown6 = 0x41; //Think this is target level.
 		OUT(instrument_mod);
-		OUT(bard_focus_id);
+		OUT(force);
 		OUT(sequence);
+		OUT(pushup_angle);
 		OUT(type);
 		OUT(spell);
 		OUT(buff_unknown);

--- a/common/patches/mac_structs.h
+++ b/common/patches/mac_structs.h
@@ -182,7 +182,7 @@ struct CombatDamage_Struct
 	/*008*/	int32	damage;
 	/*012*/	float	force;
 	/*016*/	float	sequence;
-	/*020*/	uint8	unknown20[4];
+	/*020*/	float	pushup_angle;
 	/*024*/
 };
 
@@ -194,11 +194,10 @@ struct Action_Struct
 	/*05*/	uint8	unknown5;
 	/*06*/	uint8   unknown6;  //0x41
 	/*07*/	uint8	unknown7;		// Comment: Unknown -> needs confirming 
-	/*08*/	uint8	instrument_mod;
-	/*09*/	uint32  bard_focus_id; //Seriously doubt this client uses it
-	/*13*/	uint8	unknown_zero1[3];	// Comment: Unknown -> needs confirming -> (orginal comment: lol) <- lol 
+	/*08*/	int32	instrument_mod;
+	/*12*/	float	force;
 	/*16*/	uint32	sequence;			// Comment: Heading of Who? Caster or Target? Needs confirming
-	/*20*/	uint8	unknown_zero2[4];	// Comment: Unknown -> needs confirming
+	/*20*/	float	pushup_angle;
 	/*24*/	uint8	type;				// Comment: Unknown -> needs confirming -> Which action target or caster does maybe?
 	/*25*/	uint8	unknown28[5];			// Comment: Spell ID of the Spell being casted? Needs Confirming
 	/*30*/	uint16	spell;		// Comment: Unknown -> needs confirming

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2508,7 +2508,7 @@ void Mob::BardPulse(uint16 spell_id, Mob *caster) {
 			action->source = caster->GetID();
 			action->target = GetID();
 			action->spell = spell_id;
-			action->sequence = (GetHeading() * 2);	// just some random number
+			action->sequence = (GetHeading() * 2.0f);	// just some random number
 			action->instrument_mod = caster->GetInstrumentMod(spell_id);
 			action->buff_unknown = 0;
 			action->level = buffs[buffs_i].casterlevel;
@@ -3793,9 +3793,27 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob* spelltar, bool reflect, bool use_r
 	}
 	else if(spells[spell_id].pushback != 0 || spells[spell_id].pushup != 0)
 	{
-		action->buff_unknown = 0;
+		
 		Log.Out(Logs::Detail, Logs::Spells, "Spell: %d has a pushback (%0.1f) or pushup (%0.1f) component.", spell_id, spells[spell_id].pushback, spells[spell_id].pushup);
-		spelltar->DoKnockback(this, spells[spell_id].pushback, spells[spell_id].pushup);
+
+		if (spelltar->IsNPC()) {
+			action->buff_unknown = 0;
+			spelltar->DoKnockback(this, spells[spell_id].pushback, spells[spell_id].pushup);
+		} else {
+			action->buff_unknown = 4;
+			float push_back = spells[spell_id].pushback;
+			if (push_back < 0)
+				push_back = -push_back;
+			action->force = push_back;
+			float push_up = spells[spell_id].pushup;
+			if (push_up > 0 && push_back > 0)
+			{
+				// z pushup will be translated into client as z += (force * sine(pushup_angle))
+				float ratio = push_up / push_back;
+				float angle = atanf(ratio);
+				action->pushup_angle = angle;
+			}
+		}
 	}
 
 	if(spelltar->IsClient() && spelltar->CastToClient()->GetFeigned() && IsDetrimentalSpell(spell_id))


### PR DESCRIPTION
Moved simple push on clients from spells, like Force of Ykesha to the action packet.  This prevents clients that are moving, from warping backwards, when the spell lands.