### PR TITLE
LD and Camping fixes and improvements.

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -2499,8 +2499,8 @@ bool Database::CheckAccountActive(uint32 account_id) {
 
 	if(active == 0)
 	{
-		std::string query = StringFormat("UPDATE `account` SET active = 1 WHERE id = %i", account_id);
-		QueryDatabase(query);
+		//std::string query = StringFormat("UPDATE `account` SET active = 1 WHERE id = %i", account_id);
+		//QueryDatabase(query);
 		return false;
 	}
 	else

--- a/common/eq_stream.cpp
+++ b/common/eq_stream.cpp
@@ -686,7 +686,7 @@ void EQStream::Write(int eq_fd)
 	if(GetExecutablePlatform() == ExePlatformWorld || GetExecutablePlatform() == ExePlatformZone) {
 		// if we have a timeout defined and we have not received an ack recently enough, retransmit from beginning of queue
 		if (RETRANSMIT_TIMEOUT_MULT && !SequencedQueue.empty() && NextSequencedSend &&
-			(GetState()==ESTABLISHED) && ((retransmittimer+retransmittimeout) < Timer::GetCurrentTime())) {
+			(GetState()==ESTABLISHED) && ((retransmittimer+retransmittimeout) > Timer::GetCurrentTime())) {
 			Log.Out(Logs::Detail, Logs::Netcode, _L "Timeout since last ack received, starting retransmit at the start of our unacked "
 				"buffer (seq %d, was %d)." __L, SequencedBase, SequencedBase+NextSequencedSend);
 			NextSequencedSend = 0;

--- a/common/eq_stream_factory.h
+++ b/common/eq_stream_factory.h
@@ -45,8 +45,8 @@ class EQStreamFactory : private Timeoutable {
 		uint32 stream_timeout;
 
 	public:
-		EQStreamFactory(EQStreamType type, uint32 timeout = 135000) : Timeoutable(5000), stream_timeout(timeout) { ReaderRunning=false; WriterRunning=false; StreamType=type; sock=-1; }
-		EQStreamFactory(EQStreamType type, int port, uint32 timeout = 135000);
+		EQStreamFactory(EQStreamType type, uint32 timeout = 45000) : Timeoutable(5000), stream_timeout(timeout) { ReaderRunning=false; WriterRunning=false; StreamType=type; sock=-1; }
+		EQStreamFactory(EQStreamType type, int port, uint32 timeout = 45000);
 
 		EQStream *Pop();
 		void Push(EQStream *s);

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -248,7 +248,7 @@ bool Client::HandleSendLoginInfoPacket(const EQApplicationPacket *app) {
 
 		expansion = database.GetExpansion(cle->AccountID());
 
-		if (!pZoning && ClientVersionBit != 0)
+		//if (!pZoning && ClientVersionBit != 0)
 			//SendGuildList();
 			SendLogServer();
 			SendApproveWorld();
@@ -717,8 +717,8 @@ void Client::EnterWorld(bool TryBootup) {
 	if (zoneID == 0)
 		return;
 
-	//if(GetSessionLimit())
-	//	return;
+	if(GetSessionLimit())
+		return;
 
 	ZoneServer* zs = nullptr;
 	if(instanceID > 0)

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -355,8 +355,7 @@ void ClientList::CLCheckStale() {
 			Log.Out(Logs::Detail, Logs::World_Server,"Removing stale client on account %d from %s", iterator.GetData()->AccountID(), inet_ntoa(in));
 			uint32 accountid = iterator.GetData()->AccountID();
 			iterator.RemoveCurrent();
-			if(!ActiveConnection(accountid))
-				database.ClearAccountActive(accountid);
+			database.ClearAccountActive(accountid);
 		}
 		else
 			iterator.Advance();

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -836,6 +836,9 @@ void Client::AI_Process()
 
 	if (engaged)
 	{
+		if (camp_timer.Enabled())
+			camp_timer.Disable();
+
 		if (IsRooted())
 			SetTarget(hate_list.GetClosest(this));
 		else
@@ -1060,6 +1063,9 @@ void Client::AI_Process()
 					SetRunAnimSpeed(0);
 				}
 			}
+		}
+		if (IsLD() && !camp_timer.Enabled()) {
+			camp_timer.Start(CLIENT_LD_TIMEOUT, true);
 		}
 	}
 }


### PR DESCRIPTION
Fixed a bug where the universal chat server address would not be upda…ted when logging in.
Reduced timeout for when network closes after a client crashes, after which the LD timer starts.  I would previously take over 2 minutes, before the LD process would start after a crash.
Going LD without aggro will not be as severe, the lockout will be similar to camping.
Camping normally will take you to the server select screen again.