### PR TITLE
Changed disconnect process for camping

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -131,7 +131,6 @@ bool Client::Process() {
 			Save();
 			instalog = true;
 			database.ClearAccountActive(this->AccountID());
-			return false;
 		}
 
 		if (IsStunned() && stunned_timer.Check()) {


### PR DESCRIPTION
Changed disconnect for camping so it no longer shows a message that you were disconnected.