### PR TITLE
Fixed a bug where the server list sometimes doesn't show.

### DIFF
--- a/loginserver/login_structures.h
+++ b/loginserver/login_structures.h
@@ -22,16 +22,16 @@
 
 struct ServerList_Struct {
 	uint16	numservers;
-	uint8	unknown1;
-	uint8	unknown2;
+	uint8	padding[2];
 	uint8	showusercount; // 0xFF = show numbers, 0x0 = show "UP"
 	uchar	data[0];
 };
 
 struct ServerListServerFlags_Struct {
 	uint8 greenname;
+	int32 flags; // if 0x8 then server is hidden on list
+	int32 worldid;
 	uint32 usercount;
-	uint8 unknown[8];
 };
 
 struct ServerListEndFlags_Struct {

--- a/loginserver/server_manager.cpp
+++ b/loginserver/server_manager.cpp
@@ -228,6 +228,9 @@ EQApplicationPacket* ServerManager::CreateOldServerListPacket(Client* c)
 				break;
 			}
 		}
+
+		slsf->flags = 0x1;
+		slsf->worldid = (*iter)->GetRuntimeID();
 		slsf->usercount = (*iter)->GetPlayersOnline();
 		data_ptr += sizeof(ServerListServerFlags_Struct);
 		++iter;

--- a/world/cliententry.cpp
+++ b/world/cliententry.cpp
@@ -81,6 +81,7 @@ ClientListEntry::~ClientListEntry() {
 	for (auto &elem : tell_queue)
 		safe_delete_array(elem);
 	tell_queue.clear();
+	SetOnline(CLE_Status_Offline);
 }
 
 void ClientListEntry::SetChar(uint32 iCharID, const char* iCharName) {
@@ -94,9 +95,9 @@ void ClientListEntry::SetOnline(ZoneServer* iZS, int8 iOnline) {
 }
 
 void ClientListEntry::SetOnline(int8 iOnline) {
-	if (iOnline >= CLE_Status_Online && pOnline < CLE_Status_Online)
+	if (iOnline >= CLE_Status_Zoning && pOnline < CLE_Status_Zoning)
 		numplayers++;
-	else if (iOnline < CLE_Status_Online && pOnline >= CLE_Status_Online) {
+	else if (iOnline < CLE_Status_Zoning && pOnline >= CLE_Status_Zoning) {
 		numplayers--;
 	}
 	if (iOnline != CLE_Status_Online || pOnline < CLE_Status_Online)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -867,6 +867,20 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 				}
 			}
 
+			// allow tells to corpses
+			if (targetname) {
+				if (GetTarget() && GetTarget()->IsCorpse() && GetTarget()->CastToCorpse()->IsPlayerCorpse()) {
+					if (strcasecmp(targetname,GetTarget()->CastToCorpse()->GetName()) == 0) {
+						if (strcasecmp(GetTarget()->CastToCorpse()->GetOwnerName(),GetName()) == 0) {
+							Message_StringID(MT_DefaultText, TALKING_TO_SELF);
+							return;
+						} else {
+							targetname = GetTarget()->CastToCorpse()->GetOwnerName();
+						}
+					}
+				}
+			}
+
 			char target_name[64];
 
 			if(targetname)

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -365,6 +365,7 @@
 #define GROUP_INVITEE_NOT_FOUND		12268	//You must target a player or use /invite <name> to invite someone to your group.
 #define GROUP_INVITEE_SELF			12270	//12270 You cannot invite yourself.
 #define	CAMP_ABANDON				12290	//You abandon your preparations to camp.
+#define TALKING_TO_SELF				12323	//Talking to yourself again?
 #define NOT_IN_CONTROL				12368	//You do not have control of yourself right now.
 #define TOO_DISTRACTED				12440   //You are too distracted to cast a spell now!
 #define ALREADY_CASTING				12442	//You are already casting a spell!


### PR DESCRIPTION
Server option of showusercount will now work, when set to a value other than zero.  This is currently coded to show servers as UP, rather than number of users.  The number of users was being sent in wrong location of struct before.
Server user count now updates based in being in zone, rather than just at char select screen.  Values should now be accurate.
Sending a tell to a corpse with /ttell will now relay it to their owner.