### PR TITLE
Mob position update improvements to reduce lag/disconnects.

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -422,7 +422,7 @@ bool Client::Process() {
 			// Send a position packet every 8 seconds - if not done, other clients
 			// see this char disappear after 10-12 seconds of inactivity
 			if (position_timer_counter >= 16) { // Approx. 4 ticks per second
-				entity_list.SendPositionUpdates(this, pLastUpdateWZ, 500, GetTarget(), false);
+				entity_list.SendPositionUpdates(this, pLastUpdateWZ, 300, GetTarget(), false);
 				pLastUpdate = Timer::GetCurrentTime();
 				pLastUpdateWZ = pLastUpdate;
 				position_timer_counter = 0;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1350,8 +1350,8 @@ void Mob::SendPositionNearby(uint8 iSendToSelf)
 				SpawnPositionUpdates_Struct* spu2 = (SpawnPositionUpdates_Struct*)app2->pBuffer;
 				spu2->num_updates = 1; // hack - only one spawn position per update
 				MakeSpawnUpdateNoDelta(&spu2->spawn_update);
-				entity_list.QueueCloseClientsSplit(this, app, app2, (iSendToSelf==0), 450, nullptr, false);
-				if (HasOwner())
+				entity_list.QueueCloseClientsSplit(this, app, app2, (iSendToSelf==0), 300, nullptr, false);
+				if (HasOwner() || (IsNPC() && Route.size() > 0))
 					move_tic_count = 0;
 				else
 					move_tic_count = RuleI(Zone, NPCPositonUpdateTicCount) - 6;
@@ -1359,7 +1359,7 @@ void Mob::SendPositionNearby(uint8 iSendToSelf)
 			}
 			else
 			{
-				entity_list.QueueCloseClients(this, app, (iSendToSelf==0), 450, nullptr, false);
+				entity_list.QueueCloseClients(this, app, (iSendToSelf==0), 300, nullptr, false);
 				move_tic_count++;
 			}
 		}
@@ -1389,7 +1389,7 @@ void Mob::SendPosUpdate(uint8 iSendToSelf)
 			if(CastToClient()->gmhideme)
 				entity_list.QueueClientsStatus(this,app,(iSendToSelf==0),CastToClient()->Admin(),255);
 			else
-				entity_list.QueueCloseClients(this,app,(iSendToSelf==0),450,nullptr,false);
+				entity_list.QueueCloseClients(this,app,(iSendToSelf==0),300,nullptr,false);
 		}
 		else
 		{
@@ -1401,7 +1401,7 @@ void Mob::SendPosUpdate(uint8 iSendToSelf)
 			}
 			else
 			{
-				entity_list.QueueCloseClients(this, app, (iSendToSelf==0), 450, nullptr, false);
+				entity_list.QueueCloseClients(this, app, (iSendToSelf==0), 300, nullptr, false);
 				move_tic_count++;
 			}
 		}
@@ -1627,6 +1627,8 @@ void Mob::SetCurrentSpeed(float speed) {
 			SetRunAnimSpeed(0);
 			SetMoving(false);
 			SendPosition();
+		} else {
+			move_tic_count = RuleI(Zone, NPCPositonUpdateTicCount);
 		}
 	} 
 }

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1763,7 +1763,6 @@ void NPC::AI_DoMovement() {
 						roam_z = SetBestZ(newz);
 				}
 			}
-			move_tic_count = RuleI(Zone, NPCPositonUpdateTicCount);
 		}
 
 		Log.Out(Logs::Detail, Logs::AI, "Roam Box: d=%.3f (%.3f->%.3f,%.3f->%.3f): Go To (%.3f,%.3f)",


### PR DESCRIPTION
When a mob starts to flee, they will now show that they are fleeing immediately, rather than warping to their first update.
When a mob is snared, they will immediately show their speed change.