### PR TITLE
Fix for potential crashes in Mob::AvoidDamage

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -372,6 +372,7 @@ bool Mob::AvoidDamage(Mob* other, int32 &damage, bool CanRiposte)
 	if (CanRiposte && damage > 0 && CanThisClassRiposte() && other->InFrontMob(this, other->GetX(), other->GetY()))
 	{
 		riposte_chance = (100.0f + (float)defender->aabonuses.RiposteChance + (float)defender->spellbonuses.RiposteChance + (float)defender->itembonuses.RiposteChance) / 100.0f;
+
 		skill = GetSkill(SkillRiposte);
 		if (IsClient()) {
 			CastToClient()->CheckIncreaseSkill(SkillRiposte, other, -10);
@@ -412,11 +413,10 @@ bool Mob::AvoidDamage(Mob* other, int32 &damage, bool CanRiposte)
 	float block_chance = 0.0f;
 	if (damage > 0 && CanThisClassBlock() && (other->InFrontMob(this, other->GetX(), other->GetY()) || bBlockFromRear)) {
 		block_chance = (100.0f + (float)spellbonuses.IncreaseBlockChance + (float)itembonuses.IncreaseBlockChance) / 100.0f;
+
+		skill = GetSkill(SkillBlock);
 		if (IsClient()) {
-			skill = CastToClient()->GetSkill(SkillBlock);
 			CastToClient()->CheckIncreaseSkill(SkillBlock, other, -10);
-		} else {
-			skill = GetSkill(SkillBlock);
 		}
 
 		if (!ghit) {	//if they are not using a garunteed hit discipline
@@ -455,8 +455,9 @@ bool Mob::AvoidDamage(Mob* other, int32 &damage, bool CanRiposte)
 	if (damage > 0 && CanThisClassParry() && other->InFrontMob(this, other->GetX(), other->GetY()))
 	{
 		parry_chance = (100.0f + (float)defender->spellbonuses.ParryChance + (float)defender->itembonuses.ParryChance) / 100.0f;
+
+		skill = GetSkill(SkillParry);
 		if (IsClient()) {
-			skill = CastToClient()->GetSkill(SkillParry);
 			CastToClient()->CheckIncreaseSkill(SkillParry, other, -10);
 		}
 
@@ -478,8 +479,9 @@ bool Mob::AvoidDamage(Mob* other, int32 &damage, bool CanRiposte)
 	if (damage > 0 && CanThisClassDodge() && other->InFrontMob(this, other->GetX(), other->GetY()))
 	{
 		dodge_chance = (100.0f + (float)defender->spellbonuses.DodgeChance + (float)defender->itembonuses.DodgeChance) / 100.0f;
+
+		skill = GetSkill(SkillDodge);
 		if (IsClient()) {
-			skill = CastToClient()->GetSkill(SkillDodge);
 			CastToClient()->CheckIncreaseSkill(SkillDodge, other, -10);
 		}
 


### PR DESCRIPTION
Fix for potential crashes in Mob::AvoidDamage due to uninitialized variable being used.

This was also preventing NPCs from getting their skill for block, parry, and dodge applied their chance to perform.