### PR TITLE
Pathing fixes and improvements.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2887,6 +2887,7 @@ void EntityList::AggroZone(Mob *who, int hate, bool use_ignore_dist)
 
 void EntityList::CheckNearbyNodes(Client *c)
 {
+	Mob *m = nullptr;
 	auto it = npc_list.begin();
 	while (it != npc_list.end()) {
 		if ((it->second->GetBodyType() != BT_NoTarget) && (it->second->GetBodyType() != BT_NoTarget2)) {
@@ -2894,11 +2895,20 @@ void EntityList::CheckNearbyNodes(Client *c)
 
 			int Node = zone->pathing->FindNearestPathNode(Position);
 
-			if (Node == -1)
+			if (Node == -1) {
 				c->Message(CC_Default, "Unable to locate a path node around %s at %.2f, %.2f, %.2f.", it->second->GetName(), it->second->GetX(),it->second->GetY(),it->second->GetZ());
+				if (!m)
+					m = it->second;
+			}
 		}
 		++it;
 	}
+	if (m) {
+		c->SetTarget(m);
+		m->IsTargeted(1);
+		c->SendTargetCommand(m->GetID());
+	}
+
 }
 
 // Signal Quest command function

--- a/zone/pathing.h
+++ b/zone/pathing.h
@@ -99,6 +99,7 @@ public:
 	bool NodesConnected(PathNode *a, PathNode *b);
 	void DumpPath(std::string filename);
 	void ProcessNodesAndSave(std::string filename);
+	void ConnectNearbyNodes(PathNode *center);
 	void ResortConnections();
 	void QuickConnect(Client *c, bool set = false);
 	void SortNodes();


### PR DESCRIPTION
When #path meshtest simple is run.  First disconnected node will be auto targeted.
Running #path nearest all, first mob not finding a nearby node will be auto targeted.