### PR TITLE
Fixed issue where stale ClientListEntry was clearing active accounts.

### DIFF
--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -355,7 +355,6 @@ void ClientList::CLCheckStale() {
 			Log.Out(Logs::Detail, Logs::World_Server,"Removing stale client on account %d from %s", iterator.GetData()->AccountID(), inet_ntoa(in));
 			uint32 accountid = iterator.GetData()->AccountID();
 			iterator.RemoveCurrent();
-			database.ClearAccountActive(accountid);
 		}
 		else
 			iterator.Advance();


### PR DESCRIPTION
Fixed issue where stale ClientListEntry was clearing active accounts, allowing multiple characters logged in from same account.