### PR TITLE
Fixed an issue that caused 3 pos updates after leaving grid wp.

### DIFF
--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -360,7 +360,7 @@ void NPC::CalculateNewWaypoint()
 	}
 	}
 
-	tar_ndx = 52;
+	tar_ndx = 20;
 
 	// Preserve waypoint setting for quest controlled NPCs
 	if (cur_wp < 0)


### PR DESCRIPTION
Fixed leaving grid waypoints to only send one update packet.  It was sending 2 extra position update packets unnecessarily.