### PR TITLE
Spawn Packet timing changes.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -665,7 +665,7 @@ void EntityList::AddNPC(NPC *npc, bool SendSpawnPacket, bool dontqueue)
 {
 	npc->SetID(GetFreeID());
 	//npc->SetMerchantProbability((uint8) zone->random.Int(0, 99));
-	parse->EventNPC(EVENT_SPAWN, npc, nullptr, "", 0);
+
 
 	/* Web Interface: NPC Spawn (Pop) */
 	if (RemoteCallSubscriptionHandler::Instance()->IsSubscribed("NPC.Position")) {
@@ -681,9 +681,7 @@ void EntityList::AddNPC(NPC *npc, bool SendSpawnPacket, bool dontqueue)
 		RemoteCallSubscriptionHandler::Instance()->OnEvent("NPC.Position", params);
 	}
 
-	uint16 emoteid = npc->GetEmoteID();
-	if (emoteid != 0)
-		npc->DoNPCEmote(ONSPAWN, emoteid);
+
 
 	if (SendSpawnPacket) {
 		if (dontqueue) { // aka, SEND IT NOW BITCH!
@@ -691,6 +689,13 @@ void EntityList::AddNPC(NPC *npc, bool SendSpawnPacket, bool dontqueue)
 			npc->CreateSpawnPacket(app, npc);
 			QueueClients(npc, app);
 			safe_delete(app);
+			npc->SpawnPacketSent(true);
+			parse->EventNPC(EVENT_SPAWN, npc, nullptr, "", 0);
+			if (!npc->GetDepop()) {
+				uint16 emoteid = npc->GetEmoteID();
+				if (emoteid != 0)
+					npc->DoNPCEmote(ONSPAWN, emoteid);
+			}
 		} else {
 			NewSpawn_Struct *ns = new NewSpawn_Struct;
 			memset(ns, 0, sizeof(NewSpawn_Struct));
@@ -788,6 +793,18 @@ void EntityList::CheckSpawnQueue()
 			outapp = new EQApplicationPacket;
 			Mob::CreateSpawnPacket(outapp, iterator.GetData());
 			QueueClients(0, outapp);
+			Mob* mob = GetMob(iterator.GetData()->spawn.spawnId);
+			if (mob && mob->IsNPC())
+			{
+				mob->SpawnPacketSent(true);
+				parse->EventNPC(EVENT_SPAWN, mob->CastToNPC(), nullptr, "", 0);
+				if (!mob->CastToNPC()->GetDepop()) {
+					uint16 emoteid = mob->CastToNPC()->GetEmoteID();
+					if (emoteid != 0)
+						mob->CastToNPC()->DoNPCEmote(ONSPAWN, emoteid);
+				}
+			}
+			
 			safe_delete(outapp);
 			iterator.RemoveCurrent();
 		}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -250,6 +250,7 @@ Mob::Mob(const char* in_name,
 	invulnerable = false;
 	IsFullHP	= (cur_hp == max_hp);
 	qglobal=0;
+	spawnpacket_sent = false;
 
 	InitializeBuffSlots();
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -903,6 +903,7 @@ public:
 	inline bool IsFindable() { return findable; }
 	inline uint8 GetManaPercent() { return (uint8)((float)cur_mana / (float)max_mana * 100.0f); }
 	virtual uint8 GetEndurancePercent() { return 0; }
+	inline void SpawnPacketSent(bool val) { spawnpacket_sent = val; };
 
 	inline virtual bool IsBlockedBuff(int16 SpellID) { return false; }
 	inline virtual bool IsBlockedPetBuff(int16 SpellID) { return false; }
@@ -1079,6 +1080,7 @@ protected:
 	bool held;
 	bool nocast;
 	bool focused;
+	bool spawnpacket_sent;
 	void CalcSpellBonuses(StatBonuses* newbon);
 	virtual void CalcBonuses();
 	void TrySkillProc(Mob *on, uint16 skill, uint16 ReuseTime, bool Success = false, uint16 hand = 0, bool IsDefensive = false); // hand = MainCursor?

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -538,7 +538,6 @@ void NPC::AI_Start(uint32 iMoveDelay) {
 		AIautocastspell_timer->Disable();
 	} else {
 		AIautocastspell_timer = std::unique_ptr<Timer>(new Timer(750));
-		AIautocastspell_timer->Start(RandomTimer(2000, 15000), false);
 	}
 
 	if (NPCTypedata) {
@@ -1139,7 +1138,11 @@ void Mob::DoOffHandRound(Mob* victim, ExtraAttackOptions *opts)
 }
 
 void Mob::AI_Process() {
+	
 	if (!IsAIControlled())
+		return;
+
+	if (IsNPC() && !spawnpacket_sent)
 		return;
 
 	if (!(AIthink_timer->Check() || attack_timer.Check(false)))
@@ -2817,7 +2820,7 @@ bool NPC::AI_AddNPCSpells(uint32 iDBSpellsID) {
 	if (AIspells.size() == 0)
 		AIautocastspell_timer->Disable();
 	else
-		AIautocastspell_timer->Trigger();
+		AIautocastspell_timer->Start(RandomTimer(2000, 15000), false);
 	return true;
 }
 


### PR DESCRIPTION
Added delays to performing SPAWN events, until after the spawn packet is sent for NPCs.
SPAWN emotes will now be sent after spawn packets are sent.
Fixed random delay in starting spell casting for NPCs on spawn (this was added before, but didn't actually work).