### PR TITLE
Looting item fixes.

### DIFF
--- a/common/patches/trilogy_structs.h
+++ b/common/patches/trilogy_structs.h
@@ -981,12 +981,12 @@ struct ItemOnCorpse_Struct
 
 struct LootingItem_Struct 
 {
-	/*000*/	uint16	lootee;	
-	/*002*/	uint16	looter;	
-	/*004*/	uint16	slot_id;
-	/*006*/	uint8	unknown3[2];
-	/*008*/	uint32	auto_loot;	
-	/*012*/	
+	/*000*/	uint32	lootee;	
+	/*004*/	uint32	looter;	
+	/*008*/	uint16	slot_id;
+	/*010*/	uint8	unknown3[2];
+	/*012*/	uint32	auto_loot;	
+	/*016*/	
 };
 
 struct RequestClientZoneChange_Struct 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3417,7 +3417,7 @@ void Client::Handle_OP_Emote(const EQApplicationPacket *app)
 
 void Client::Handle_OP_EndLootRequest(const EQApplicationPacket *app)
 {
-	if (app->size != sizeof(uint16)) {
+	if (app->size != sizeof(uint16) && app->size != sizeof(uint32)) {
 		std::cout << "Wrong size: OP_EndLootRequest, size=" << app->size << ", expected " << sizeof(uint16) << std::endl;
 		return;
 	}


### PR DESCRIPTION
Fixed LootingItem_Struct.
Fixed checks against size of OP_EndLootRequest.  This should allow looting items from NPC corpses.