### PR TITLE
Charm Fixes.

### DIFF
--- a/common/eq_stream.cpp
+++ b/common/eq_stream.cpp
@@ -2100,9 +2100,8 @@ void EQOldStream::MakeEQPacket(EQProtocolPacket* app, bool ack_req)
 
 			if(app->size && app->pBuffer)
 			{
-				EmuOpcode app_opcode = (*OpMgr)->EQToEmu(app->opcode);
-
 				if (Log.log_settings[Logs::Server_Client_Packet].is_category_enabled == 1){
+					EmuOpcode app_opcode = (*OpMgr)->EQToEmu(app->opcode);
 					if (app_opcode != OP_SpecialMesg && 
 						(!RuleB(EventLog, SkipCommonPacketLogging) ||
 						(RuleB(EventLog, SkipCommonPacketLogging) && app_opcode != OP_MobHealth && app_opcode != OP_MobUpdate && app_opcode != OP_ClientUpdate))){
@@ -2111,6 +2110,7 @@ void EQOldStream::MakeEQPacket(EQProtocolPacket* app, bool ack_req)
 				}
 
 				if (Log.log_settings[Logs::Server_Client_Packet_With_Dump].is_category_enabled == 1){
+					EmuOpcode app_opcode = (*OpMgr)->EQToEmu(app->opcode);
 					if (app_opcode != OP_SpecialMesg && 
 						(!RuleB(EventLog, SkipCommonPacketLogging) ||
 						(RuleB(EventLog, SkipCommonPacketLogging) && app_opcode != OP_MobHealth && app_opcode != OP_MobUpdate && app_opcode != OP_ClientUpdate))){

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2253,6 +2253,8 @@ void Mob::FaceTarget(Mob* MobToFace) {
 
 bool Mob::RemoveFromHateList(Mob* mob)
 {
+	if (!IsAIControlled())
+		return false;
 	SetRunAnimSpeed(0);
 	bool bFound = false;
 	if(IsEngaged())

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3732,7 +3732,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses, bool message)
 				SetOwnerID(0);
 				if(tempmob)
 				{
-					if(tempmob->GetTarget() && tempmob->GetTarget() == this)
+					if(tempmob->IsNPC() && tempmob->GetTarget() && tempmob->GetTarget() == this)
 						tempmob->SetTarget(nullptr);
 
 					tempmob->SetPet(0);
@@ -3762,7 +3762,6 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses, bool message)
 					ps->command = 0;
 					entity_list.QueueClients(this, app);
 					safe_delete(app);
-					tempmob->SetTarget(this);
 				}
 				if(IsClient())
 				{


### PR DESCRIPTION
Players that have charmed mobs targeted, will no longer have their target go invalid after charm breaks.  No more re-targeting required.
Moved some log support code inside the logic if that logging is on for packets.  That way the check is only performed during logging, not every single packet.