### PR TITLE
Packet Logging improvements.

### DIFF
--- a/common/eq_stream.cpp
+++ b/common/eq_stream.cpp
@@ -2100,21 +2100,21 @@ void EQOldStream::MakeEQPacket(EQProtocolPacket* app, bool ack_req)
 
 			if(app->size && app->pBuffer)
 			{
-				EmuOpcode app_opcode = (*OpMgr)->EQToEmu(app->opcode);
-
 				if (Log.log_settings[Logs::Server_Client_Packet].is_category_enabled == 1){
+					EmuOpcode app_opcode = (*OpMgr)->EQToEmu(app->opcode);
 					if (app_opcode != OP_SpecialMesg && 
 						(!RuleB(EventLog, SkipCommonPacketLogging) ||
 						(RuleB(EventLog, SkipCommonPacketLogging) && app_opcode != OP_MobHealth && app_opcode != OP_MobUpdate && app_opcode != OP_ClientUpdate))){
-					Log.Out(Logs::General, Logs::Server_Client_Packet, "[%s - 0x%04x] [Size: %u]", OpcodeManager::EmuToName(app_opcode), app_opcode, app->size);
+					Log.Out(Logs::General, Logs::Server_Client_Packet, "[%s - 0x%04x] [Size: %u]", OpcodeManager::EmuToName(app_opcode), app->opcode, app->size);
 					}
 				}
 
 				if (Log.log_settings[Logs::Server_Client_Packet_With_Dump].is_category_enabled == 1){
+					EmuOpcode app_opcode = (*OpMgr)->EQToEmu(app->opcode);
 					if (app_opcode != OP_SpecialMesg && 
 						(!RuleB(EventLog, SkipCommonPacketLogging) ||
 						(RuleB(EventLog, SkipCommonPacketLogging) && app_opcode != OP_MobHealth && app_opcode != OP_MobUpdate && app_opcode != OP_ClientUpdate))){
-						Log.Out(Logs::General, Logs::Server_Client_Packet_With_Dump, "[%s - 0x%04x] [Size: %u] %s", OpcodeManager::EmuToName(app_opcode), app_opcode, app->size, DumpProtocolPacketToString(app).c_str());
+						Log.Out(Logs::General, Logs::Server_Client_Packet_With_Dump, "[%s - 0x%04x] [Size: %u] %s", OpcodeManager::EmuToName(app_opcode), app->opcode, app->size, DumpProtocolPacketToString(app).c_str());
 					}
 				}
 


### PR DESCRIPTION
Moved some logic for some extra checks associated with logging.
Server to Client packet logging, will now show the actual opcode along with the translated name.  The emu opcode was shown before, which provided no value added.