### PR TITLE
Fixed some rounding issues with clients vs server locs.

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -288,9 +288,78 @@ struct ClientZoneEntry_Struct {
 ** OPCodes: OP_ServerZoneEntry
 **
 */
-struct ServerZoneEntry_Struct
+struct ServerZoneEntry_Struct 
 {
-	struct NewSpawn_Struct player;
+	/*0000*/	uint8	checksum[4];		// Checksum
+	/*0004*/	uint8	type;		// ***Placeholder
+	/*0005*/	char	name[64];			// Name
+	/*0069*/	uint8	sze_unknown0069;	// ***Placeholder
+	/*0070*/	uint16	unknown0070;		// ***Placeholder
+	/*0072*/	uint32	zoneID;				// Current Zone
+	/*0076*/	float	y_pos;				// Y Position
+	/*0080*/	float	x_pos;				// X Position
+	/*0084*/	float	z_pos;				// Z Position
+	/*0088*/	float	heading;
+	/*0092*/	float	physicsinfo[8];
+	/*0124*/	int32	prev;
+	/*0128*/	int32	next;
+	/*0132*/	int32	corpse;
+	/*0136*/	int32	LocalInfo;
+	/*0140*/	int32	My_Char;
+	/*0144*/	float	view_height;
+	/*0148*/	float	sprite_oheight;
+	/*0152*/	uint16	sprite_oheights;
+	/*0154*/	uint16	petOwnerId;
+	/*0156*/	uint32	max_hp;
+	/*0160*/	uint32	curHP;
+	/*0164*/	uint16	GuildID;			// Guild ID Number
+	/*0166*/	uint8	my_socket[6];		// ***Placeholder
+	/*0172*/	uint8	NPC;
+	/*0173*/	uint8	class_;				// Class
+	/*0174*/	uint16	race;				// Race
+	/*0176*/	uint8	gender;				// Gender
+	/*0177*/	uint8	level;				// Level
+	/*0178*/	uint8	invis;
+	/*0179*/	uint8	sneaking;
+	/*0180*/	uint8	pvp;				// PVP Flag
+	/*0181*/	uint8	anim_type;
+	/*0182*/	uint8	light;
+	/*0183*/	int8	face;				// Face Type
+	/*0184*/    uint16  equipment[9]; // Array elements correspond to struct equipment above
+	/*0202*/	uint16	unknown; //Probably part of equipment
+	/*0204*/	Color_Struct equipcolors[9]; // Array elements correspond to struct equipment_colors above
+	/*0240*/	uint32	bodytexture;	// Texture (0xFF=Player - See list of textures for more)
+	/*0244*/	float	size;
+	/*0248*/	float	width;
+	/*0252*/	float	length;
+	/*0256*/	uint32	helm;
+	/*0260*/	float	walkspeed;			// Speed when you walk
+	/*0264*/	float	runspeed;			// Speed when you run
+	/*0268*/	int8	LD;
+	/*0269*/	int8	GM;
+	/*0270*/	int16	flymode;
+	/*0272*/	int8	bodytype;
+	/*0273*/	int8	view_player[7];
+	/*0280*/	uint8	anon;				// Anon. Flag
+	/*0281*/	uint16	avatar;
+	/*0283*/	uint8	AFK;
+	/*0284*/	uint8	summoned_pc;
+	/*0285*/	uint8	title;
+	/*0286*/	uint8	extra[18];	// ***Placeholder (At least one flag in here disables a zone point or all)
+	/*0304*/	char	Surname[32];		// Lastname (This has to be wrong.. but 70 is to big =/..)
+	/*0336*/	uint16  guildrank;
+	/*0338*/	uint16	deity;				// Diety (Who you worship for those less literate)
+	/*0340*/	uint8	animation;		// ***Placeholder
+	/*0341*/	uint8	haircolor;			// Hair Color
+	/*0342*/	uint8	beardcolor;			// Beard Color
+	/*0343*/	uint8	eyecolor1;			// Left Eye Color
+	/*0344*/	uint8	eyecolor2;			// Right Eye Color
+	/*0345*/	uint8	hairstyle;			// Hair Style
+	/*0346*/	uint8	beard;				// AA Title
+	/*0347*/	uint32	SerialNumber;
+	/*0351*/	char	m_bTemporaryPet[4];
+	/*0355*/	uint8	void_;
+	/*0356*/
 };
 
 //This should be treated as an internal struct

--- a/common/patches/mac.cpp
+++ b/common/patches/mac.cpp
@@ -154,85 +154,8 @@ namespace Mac {
 	ENCODE(OP_ZoneEntry)
 	{ 
 		SETUP_DIRECT_ENCODE(ServerZoneEntry_Struct, structs::ServerZoneEntry_Struct);
-
-			int k = 0;
-			eq->zoneID = emu->player.spawn.zoneID;
-			eq->anon = emu->player.spawn.anon;
-			strncpy(eq->name, emu->player.spawn.name, 64);
-			eq->deity = emu->player.spawn.deity;
-			eq->race = emu->player.spawn.race;
-			if ((emu->player.spawn.race == 42 || emu->player.spawn.race == 120) && emu->player.spawn.gender == 2)
-			{
-				eq->size = emu->player.spawn.size + 4.0f;
-				eq->width = emu->player.spawn.size + 4.0f;
-			}
-			else
-			{
-				eq->size = emu->player.spawn.size;
-				eq->width = emu->player.spawn.size;
-			}
-			
-			eq->NPC = emu->player.spawn.NPC;
-			eq->invis = emu->player.spawn.invis;
-			eq->max_hp = emu->player.spawn.max_hp;
-			eq->curHP = emu->player.spawn.curHp;
-			eq->x_pos = (float)emu->player.spawn.x;
-			eq->y_pos = (float)emu->player.spawn.y;
-			eq->z_pos = (float)emu->player.spawn.z;
-			eq->animation = emu->player.spawn.animation;
-			eq->heading = (float)emu->player.spawn.heading;
-			eq->haircolor = emu->player.spawn.haircolor;
-			eq->beardcolor = emu->player.spawn.beardcolor;
-			eq->eyecolor1 = emu->player.spawn.eyecolor1;
-			eq->eyecolor2 = emu->player.spawn.eyecolor2;
-			eq->hairstyle = emu->player.spawn.hairstyle;
-			eq->beard = emu->player.spawn.beard;
-			eq->face = emu->player.spawn.face;
-			eq->level = emu->player.spawn.level;
-			for(k = 0; k < 9; k++) 
-			{
-				eq->equipment[k] = emu->player.spawn.equipment[k];
-				eq->equipcolors[k].color = emu->player.spawn.colors[k].color;
-			}
-			eq->AFK = emu->player.spawn.afk;
-			eq->title = emu->player.spawn.aaitle;
-			eq->anim_type = 0x64;
-			eq->bodytexture = emu->player.spawn.bodytexture;
-			eq->helm = emu->player.spawn.helm;
-			eq->GM = emu->player.spawn.gm;
-			eq->GuildID = emu->player.spawn.guildID;
-			if(eq->GuildID == 0)
-				eq->GuildID = 0xFFFF;
-			eq->guildrank = emu->player.spawn.guildrank;
-			if(eq->guildrank == 0)
-				eq->guildrank = 0xFFFF;
-			strncpy(eq->Surname, emu->player.spawn.lastName, 32);
-			eq->walkspeed = emu->player.spawn.walkspeed;
-			eq->runspeed = emu->player.spawn.runspeed;
-			eq->light = emu->player.spawn.light;
-			if(emu->player.spawn.class_ > 19 && emu->player.spawn.class_ < 35)
-				eq->class_ = emu->player.spawn.class_-3;
-			else if(emu->player.spawn.class_ == 40)
-				eq->class_ = 16;
-			else if(emu->player.spawn.class_ == 41)
-				eq->class_ = 32;
-			else 
-				eq->class_ = emu->player.spawn.class_;
-			eq->gender = emu->player.spawn.gender;
-			eq->flymode = emu->player.spawn.flymode;
-			eq->prev = 0xa0ae0e00;
-			eq->next = 0xa0ae0e00;
-			eq->view_height = 0x6666c640;
-			eq->sprite_oheight = 0x00004840;
-			eq->extra[10] = 0xFF;
-			eq->extra[11] = 0xFF;
-			eq->extra[12] = 0xFF;
-			eq->extra[13] = 0xFF;
-			eq->type = 0;
-			eq->petOwnerId = emu->player.spawn.petOwnerId;
-
+			memcpy(eq, emu, sizeof(structs::ServerZoneEntry_Struct));
 			CRC32::SetEQChecksum(__packet->pBuffer, sizeof(structs::ServerZoneEntry_Struct));
-
 		FINISH_ENCODE();
 	}
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1394,8 +1394,8 @@ void Mob::MakeSpawnUpdateNoDelta(SpawnPositionUpdate_Struct *spu)
 	memset(spu,0xff,sizeof(SpawnPositionUpdate_Struct));
 
 	spu->spawn_id	= GetID();
-	spu->x_pos = static_cast<int16>(m_Position.x);
-	spu->y_pos = static_cast<int16>(m_Position.y);
+	spu->x_pos = static_cast<int16>(m_Position.x + 0.5f);
+	spu->y_pos = static_cast<int16>(m_Position.y + 0.5f);
 	spu->z_pos = static_cast<int16>((m_Position.z)*10);
 	spu->heading	= static_cast<int8>(m_Position.w);
 
@@ -1427,8 +1427,8 @@ void Mob::MakeSpawnUpdate(SpawnPositionUpdate_Struct* spu)
 	auto currentloc = glm::vec4(GetX(), GetY(), GetZ(), GetHeading());
 
 	spu->spawn_id	= GetID();
-	spu->x_pos = static_cast<int16>(m_Position.x);
-	spu->y_pos = static_cast<int16>(m_Position.y);
+	spu->x_pos = static_cast<int16>(m_Position.x + 0.5f);
+	spu->y_pos = static_cast<int16>(m_Position.y + 0.5f);
 	spu->z_pos = static_cast<int16>(10.0f * m_Position.z);
 	spu->heading	= static_cast<int8>(currentloc.w);
 

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -508,14 +508,14 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 			y = m_Position.y = m_pp.binds[0].y;
 			z = m_Position.z = m_pp.binds[0].z;
 			heading = m_pp.binds[0].heading;
-			m_Position.w = heading / 2.0f;
+			m_Position.w = heading * 255.0f / 512.0f;
 			break;
 		case ZoneToBindPoint:
 			x = m_Position.x = m_pp.binds[0].x;
 			y = m_Position.y = m_pp.binds[0].y;
 			z = m_Position.z = m_pp.binds[0].z;
 			heading = m_pp.binds[0].heading;
-			m_Position.w = heading / 2.0f;
+			m_Position.w = heading * 255.0f / 512.0f;
 
 			zonesummon_ignorerestrictions = 1;
 			Log.Out(Logs::General, Logs::None, "Player %s has died and will be zoned to bind point in zone: %s at LOC x=%f, y=%f, z=%f, heading=%f", GetName(), pZoneName, m_pp.binds[0].x, m_pp.binds[0].y, m_pp.binds[0].z, m_pp.binds[0].heading);


### PR DESCRIPTION
Client and Server will round their positions the same way now, when converting x and y coordinates from float to int.
Changed encoding for ServerZoneEntry_Struct to be direct, so as to not round positions and heading.  This helps prevent client loc and heading changing when logging in.
Fixed an issue with the z adjustment for clients, using zone geometry when logging in.  It was not updating correctly based on the real value for bestz.