### PR TITLE
fixed bug where HOWLERS (seb/HS portals) would not allow subsequent c…

### DIFF
--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -332,15 +332,18 @@ void Doors::HandleClick(Client* sender, uint8 trigger)
 	}
 
 	entity_list.QueueClients(sender, outapp, false);
-	if(!IsDoorOpen() || (opentype == 58))
+	if (strcmp(door_name, "HOWLER") != 0)
 	{
-		close_timer.Start();
-		SetOpenState(true);
-	}
-	else
-	{
-		close_timer.Disable();
-		SetOpenState(false);
+		if (!IsDoorOpen() || (opentype == 58))
+		{
+			close_timer.Start();
+			SetOpenState(true);
+		}
+		else
+		{
+			close_timer.Disable();
+			SetOpenState(false);
+		}
 	}
 
 	//everything past this point assumes we opened the door

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -332,18 +332,15 @@ void Doors::HandleClick(Client* sender, uint8 trigger)
 	}
 
 	entity_list.QueueClients(sender, outapp, false);
-	if (strcmp(door_name, "HOWLER") != 0)
+	if (!IsDoorOpen())
 	{
-		if (!IsDoorOpen() || (opentype == 58))
-		{
-			close_timer.Start();
-			SetOpenState(true);
-		}
-		else
-		{
-			close_timer.Disable();
-			SetOpenState(false);
-		}
+		close_timer.Start();
+		SetOpenState(true);
+	}
+	else
+	{
+		close_timer.Disable();
+		SetOpenState(false);
 	}
 
 	//everything past this point assumes we opened the door


### PR DESCRIPTION
…lients to click using keyring


trying to use your keyring (not holding the key) on the howlers (seb/HS portal) right after someone else used their keyring to enter would not work... 

this bug http://www.takproject.net/forums/index.php?threads/seb-key-and-keyring.4415/#post-24462

I commented out the part where it says 

close_timer.Start()
SetOpenState(true)

and it worked. so i added logic to check if door name was = to howler than to skip that.



btw I could zone in 2 toons simultaneous into VP with no problem, and that door name is not called HOWLER... so i'm guessing it has something to do with HOWLERS specifically.

if this happens on the sleeper tomb portal (which is not called HOWLER) then maybe we can change these door opentypes to something not being used. but that would require changing more code to fit this new opentype... the other option is to keep adding to this if statement the door_names where these portals fail to work.


