### PR TITLE
Added <ctime> to common/base_packet.h for linux builds

### DIFF
--- a/common/base_packet.h
+++ b/common/base_packet.h
@@ -28,6 +28,7 @@
 	#include <windows.h>
 #else
 	#include <sys/time.h>
+	#include <ctime>
 	#include <netinet/in.h>
 #endif
 

--- a/loginserver/login_util/login.ini
+++ b/loginserver/login_util/login.ini
@@ -7,7 +7,7 @@ password = password
 subsystem = MySQL
 
 [options]
-auto_account_create = FALSE
+auto_create_accounts = FALSE
 auto_account_activate = FALSE
 failed_login_log = FALSE
 good_loginIP_log = FALSE
@@ -27,7 +27,7 @@ plugin = EQEmuAuthCrypto
 mode = 5
 
 [Old]
-clientport = 6000
+port = 6000
 opcodes = login_opcodes_oldver.conf
 
 [schema]
@@ -36,3 +36,4 @@ account_table = tblLoginServerAccounts
 world_registration_table = tblWorldServerRegistration
 world_admin_registration_table = tblServerAdminRegistration
 world_server_type_table = tblServerListType
+loginserver_setting_table = tblloginserversettings


### PR DESCRIPTION
* Builds were failing because linux expects <ctime> to be #included
* login.ini had incorrect labels for some options and some missing options preventing login server from allowing clients to connect and login