### PR TITLE
Fix for crashes observed in Client::PutLootInInventory and lua command unique_spawn where FixHeading would infinite loop (observed in neriakb)

### DIFF
--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -675,6 +675,11 @@ void Client::PutLootInInventory(int16 slot_id, const EQ::ItemInstance &inst, Ser
 		{
 			if(bag_item_data[i] == nullptr)
 				continue;
+
+			const EQ::ItemData* sub_item_item_data = database.GetItem(bag_item_data[i]->item_id);
+			if(sub_item_item_data == nullptr)
+				continue;
+
 			const EQ::ItemInstance *bagitem = database.CreateItem(bag_item_data[i]->item_id, bag_item_data[i]->charges);
 			interior_slot = EQ::InventoryProfile::CalcSlotId(slot_id, i);
 			Log(Logs::Detail, Logs::Inventory, "Putting bag loot item %s (%d) into slot %d (bag slot %d)", inst.GetItem()->Name, inst.GetItem()->ID, interior_slot, i);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -266,17 +266,22 @@ void unregister_spell_event(int evt, int spell_id) {
 }
 
 Lua_Mob lua_spawn2(int npc_type, int grid, int unused, double x, double y, double z, double heading) {
-	auto position = glm::vec4(x, y, z, heading);
+	glm::vec4 position = glm::vec4(x, y, z, heading);
 	return Lua_Mob(quest_manager.spawn2(npc_type, grid, unused, position));
 }
 
 Lua_Mob lua_spawn2(int npc_type, int grid, int unused, double x, double y, double z, double heading, const char* name) {
-	auto position = glm::vec4(x, y, z, heading);
+	glm::vec4 position = glm::vec4(x, y, z, heading);
 	return Lua_Mob(quest_manager.spawn2(npc_type, grid, unused, position, name));
 }
 
-Lua_Mob lua_unique_spawn(int npc_type, int grid, int unused, double x, double y, double z, double heading = 0.0) {
-	auto position = glm::vec4(x, y, z, heading);
+Lua_Mob lua_unique_spawn(int npc_type, int grid, int unused, double x, double y, double z) {
+	glm::vec4 position = glm::vec4(x, y, z, 0.0);
+	return Lua_Mob(quest_manager.unique_spawn(npc_type, grid, unused, position));
+}
+
+Lua_Mob lua_unique_spawn(int npc_type, int grid, int unused, double x, double y, double z, double heading) {
+	glm::vec4 position = glm::vec4(x, y, z, heading);
 	return Lua_Mob(quest_manager.unique_spawn(npc_type, grid, unused, position));
 }
 


### PR DESCRIPTION
The first crash is a missing nullptr check - if an item is looted on a corpse that doesn't exist in the database.

The second crash - Heading had a default value of 0.0f in the local parameters, which would be casted to inf (or NaN, really) if the parameter wasn't explicitly specified. Instead of fixing every script retroactively, I opted to fix this by explicitly specifying heading and the version for eq.unique_spawn calls into C++ from lua.