### PR TITLE
added check for missing Maps dir and map files

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -108,6 +108,12 @@ bool Zone::Bootup(uint32 iZoneID, bool iStaticZone) {
 	zone->zonemap = Map::LoadMapFile(zone->map_name);
 	zone->watermap = WaterMap::LoadWaterMapfile(zone->map_name);
 	zone->pathing = IPathfinder::Load(zone->map_name);
+	if (zone->zonemap == nullptr || zone->watermap == nullptr) {
+		std::cerr << "Zone->Loading map files failed for Maps/" << zone->map_name << std::endl;
+		safe_delete(zone);
+		worldserver.SetZoneData(0);
+		return false;
+	}
 
 	std::string tmp;
 	if (database.GetVariable("loglevel", tmp)) {


### PR DESCRIPTION
If Maps/ dir doesn't exist then some zones crash after a few seconds of being up leading to a stack trace ultimately in Map::FindBestZ zone/map.cpp:108 from mob_ai.cpp... not the easiest error message to follow when someone names Maps dir maps/ instead of Maps/

```
LogInfo("{} is using {} for its map_name", zonename, zone->map_name);
zone->zonemap = Map::LoadMapFile(zone->map_name);
zone->watermap = WaterMap::LoadWaterMapfile(zone->map_name);
zone->pathing = IPathfinder::Load(zone->map_name);
```

unfortunately all 3 of these 'Load' functions handle the naming convention of the Maps/ dir differently.
additionally, IPathfinder's Load returns a special null class while the other 2 will return nullptr.
would have liked to check all 3 for nonexistence, but too much for minimal issue


now instead of stack traces logged to logs/crashes/mapname.log, the regular logs/zone-mapname.log contains the following message

```
root@46d989864a05:/takp/logs# tail -5 zone-firiona.log 
[ZoneServer] [Info] Init Finished: ZoneID = 84, Time Offset = 0 
[ZoneServer] [Info] firiona is using firiona for its map_name
Zone->Loading map files failed for Maps/firiona
[ZoneServer] [Error] Zone Bootup failed :: Zone::Bootup
[ZoneServer] [Info] Starting EQ Network server on port 7383 
```

additionally, trying to enter any zone now from character select presents "The zone is unavailable" instead of letting you log in and crashing few seconds later