### PR TITLE
IsMoving() now usable on clients

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3047,6 +3047,8 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app)
 		rewind_timer.Start(30000, true);
 	}
 
+	SetMoving(!(ppu->y_pos  == m_Position.y && ppu->x_pos == m_Position.x));
+
 	if (door_check_timer.Check())
 	{
 		entity_list.OpenFloorTeleportNear(this);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3046,8 +3046,9 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app)
 		*/
 		rewind_timer.Start(30000, true);
 	}
-
-	SetMoving(!(ppu->y_pos  == m_Position.y && ppu->x_pos == m_Position.x));
+	
+	if (!IsAIControlled())
+		SetMoving(!(ppu->y_pos  == m_Position.y && ppu->x_pos == m_Position.x));
 
 	if (door_check_timer.Check())
 	{


### PR DESCRIPTION
Adds a SetMoving() line to ClientUpdate similar to PEQ. Allows the use of IsMoving() on Clients.