### PR TITLE
spell + monk feign breaks charm pets

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2213,6 +2213,10 @@ void Client::SetFeigned(bool in_feigned) {
 		{
 			SetPet(0);
 		}
+		// feign breaks charmed pets
+		if (GetPet() && GetPet()->IsCharmedPet()) {
+			FadePetCharmBuff();
+		}
 		SetHorseId(0);
 		feigned_time = Timer::GetCurrentTime();
 	}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1444,8 +1444,6 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, int buffslot, int caster_lev
 						}
 						else
 						{
-							if (GetPet() && GetPet()->IsCharmedPet())
-								FadePetCharmBuff();
 							CastToClient()->SetFeigned(true);
 						}
 					}


### PR DESCRIPTION
@SecretsOTheP said to put in PR here

Does what title says. Spell feign was breaking charm correctly. Monk feign was not. This PR should correct the issue.