### PR TITLE
fix for faction hits + feign faction

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1891,12 +1891,6 @@ bool NPC::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::SkillTyp
 		respawn2->DeathReset(true);
 	}
 
-	// Do faction hits to any player on the hatelist, so long as a player damaged us.
-	if (GetNPCFactionID() > 0 && player_damaged)
-	{
-		hate_list.DoFactionHits(GetNPCFactionID(), faction);
-	}
-
 	// Killer is whoever gets corpse rights. Corpse will be left if killer is a player.
 	int32 dmg_amt = 0;
 	Mob* killer = nullptr;
@@ -1994,6 +1988,11 @@ bool NPC::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::SkillTyp
 		Log(Logs::Moderate, Logs::Death, "Killer is NULL or is a NPC. No corpse will be left.");
 	}
 
+	// Do faction hits to players on hatelist so long as killer is client and npc didn't get killing blow
+	if (GetNPCFactionID() > 0 && player_damaged && killer && (killer != oos || killer->IsClient()))
+	{
+		hate_list.DoFactionHits(GetNPCFactionID(), faction);
+	}
 	
 	hate_list.ReportDmgTotals(this, corpse, xp, faction, dmg_amt);
 	BuffFadeAll();

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2247,6 +2247,7 @@ void Client::SetFeigned(bool in_feigned) {
 			entity_list.ClearFeignAggro(this);
 	}
 	feigned=in_feigned;
+	entity_list.NotifyFeigned(this, feigned);
  }
 
 void Client::LogMerchant(Client* player, Mob* merchant, uint32 quantity, uint32 price, const EQ::ItemData* item, bool buying)

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3174,6 +3174,23 @@ void EntityList::ClearAggro(Mob* targ)
 	}
 }
 
+void EntityList::NotifyFeigned(Mob* targ, bool feigned) {
+	auto it = npc_list.begin();
+	while (it != npc_list.end()) {
+		tHateEntry* hateEntry = it->second->GetHateEntryFor(targ);
+		if (hateEntry) {
+			if (feigned) {
+				if (!it->second->IsFleeing()) {
+					hateEntry->feignedBeforeFleeing = true;
+				}
+			}
+			else {
+				hateEntry->feignedBeforeFleeing = false;
+			}
+		}
+	}
+}
+
 // this is called when the player stands up
 // stun_elapsed is the number of miliseconds elapsed since stun timer has started; 0 if client not stunned
 void EntityList::ClearFeignAggro(Mob *targ)

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -365,6 +365,7 @@ public:
 
 	void	Process();
 	void	ClearAggro(Mob* targ);
+	void	NotifyFeigned(Mob* targ, bool feigned);
 	void	ClearFeignAggro(Mob* targ);
 	void	AggroZone(Mob* who, int hate = 0, bool use_ignore_dist = false);
 

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -527,6 +527,7 @@ void HateList::Add(Mob *ent, int32 in_hate, int32 in_dam, bool bFrenzy, bool iAd
 		}
 		p->hate = in_hate;
 		p->bFrenzy = bFrenzy;
+		p->feignedBeforeFleeing = false;
 		list.push_back(p);
 		parse->EventNPC(EVENT_HATE_LIST, owner->CastToNPC(), ent, "1", 0);
 		Log(Logs::Moderate, Logs::Aggro, "%s is creating %d damage and %d hate on %s hatelist.", ent->GetName(), in_dam, in_hate, owner->GetName());
@@ -579,7 +580,6 @@ void HateList::DoFactionHits(int32 nfl_id, bool &success) {
 	while(iterator != list.end())
 	{
 		Client *p;
-
 		if ((*iterator)->ent && (*iterator)->ent->IsClient())
 			p = (*iterator)->ent->CastToClient();
 		else
@@ -587,8 +587,10 @@ void HateList::DoFactionHits(int32 nfl_id, bool &success) {
 
 		if (p)
 		{
-			if (!p->IsFeigned() || (owner->IsFleeing() && !owner->IsRooted() && (Distance(owner->GetPosition(), p->GetPosition()) < 100.0f)))
-			p->SetFactionLevel(p->CharacterID(), nfl_id);
+			bool feignedBeforeFleeing = (*iterator)->feignedBeforeFleeing;
+			if (!p->IsFeigned() || (!feignedBeforeFleeing && owner->IsFleeing() && !owner->IsRooted() && (Distance(owner->GetPosition(), p->GetPosition()) < 100.0f))) {
+				p->SetFactionLevel(p->CharacterID(), nfl_id);
+			}
 			success = true;
 		}
 		++iterator;

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -32,6 +32,7 @@ struct tHateEntry
 	float dist_squared;
 	uint32 last_damage;
 	uint32 last_hate;
+	bool feignedBeforeFleeing;
 };
 
 class HateList
@@ -107,8 +108,9 @@ public:
 
 	void ReportDmgTotals(Mob* mob, bool corpse, bool xp, bool faction, int32 dmg_amt);
 
+	tHateEntry* Find(Mob* ent);
+
 protected:
-	tHateEntry* Find(Mob *ent);
 	int32 GetHateBonus(tHateEntry *entry, bool combatRange, bool firstInRange = false, float distSquared = -1.0f);
 	int32 GetEntPetDamage(Mob* ent);
 private:

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -801,6 +801,8 @@ public:
 	void SetMoved(bool val) { moved = val; }
 
 	inline bool			CheckAggro(Mob* other) { return hate_list.IsOnHateList(other); }
+	inline tHateEntry*	GetHateEntryFor(Mob* ent) { return hate_list.Find(ent); }
+
 	float				CalculateHeadingToTarget(float in_x, float in_y) { return HeadingAngleToMob(in_x, in_y); }
 	float				CalculatePitchToTarget(glm::vec3 loc);
 	virtual void		WalkTo(float x, float y, float z);


### PR DESCRIPTION
Haven't had chance to test this PR if somebody can help out. Will test this when I have some time.

From what Elroz has told me the following should be the mechanics for faction hits:

1) Non-pet NPC gets killing blow = no corpse, no faction, no xp
2) Client does >50% of damage and non-pet NPC does not get killing blow = xp, faction, corpse.

This change should implement those mechanics

------

Second part of this PR adds an attribute to the hatelist entry struct to indicate whether a feign occurred before fleeing. On feign we update this attribute to true if the mob is not fleeing. The mechanics for this should be:

1) If a player feigns before a mob starts fleeing then no faction hit will occur. 
2) If a player feigns after a mob starts fleeing then faction hit will occur.

This change should only affect faction hits and nothing else. Not sure if there's a more efficient way to do this and looping through npc_list on every feign may not be feasible but I don't know. Open to suggestions to other ways to implement this.