### PR TITLE
Update EQServer(public-release).sh fixes plugins symlink

### DIFF
--- a/utils/scripts/EQServer(public-release).sh
+++ b/utils/scripts/EQServer(public-release).sh
@@ -526,6 +526,7 @@ downloadQuests)
 	else
 		echo dir does not exist, grabbing clone from git...
 		git clone https://github.com/EQMacEmu/peqmacquests $path/quests
+  		cp -r $path/source/utils/defaults/plugins $path/quests/plugins
 		ln -s $path/quests/plugins $path/plugins
 		ln -s $path/quests/lua_modules $path/lua_modules
 	fi


### PR DESCRIPTION
Fixes broken symlink to quests/plugins folder by copying the default plugins from the source folder