### PR TITLE
Update worlddb.cpp fixes git fatal error due to typo

### DIFF
--- a/world/worlddb.cpp
+++ b/world/worlddb.cpp
@@ -549,7 +549,7 @@ bool WorldDatabase::GITInfo()
 	char* buf = NULL;
 	size_t len = 0;
 	fflush(NULL);
-	std::string gitParseHead = StringFormat("git --git-dir=%s rev-parse rev-parse HEAD", source_path);
+	std::string gitParseHead = StringFormat("git --git-dir=%s rev-parse HEAD", source_path);
 	fhash = popen(gitParseHead.c_str(), "r");
 
 	while (getline(&buf, &len, fhash) != -1)


### PR DESCRIPTION
git command had a duplicate "rev-parse" argument that was causing a fatal error to that git command during launch of world process.

You can reproduce this by commenting out the /dev/null redirection in the EQServer.sh launch script and observing the message in stderr.