### PR TITLE
Update EQServer(public-release).sh

### DIFF
--- a/utils/scripts/EQServer(public-release).sh
+++ b/utils/scripts/EQServer(public-release).sh
@@ -70,7 +70,7 @@ if  [ $dynamic2 = "TRUE" ]; then
 	let zonecount_temp=$((zonecount_temp+dynamiccount2))
 fi
 
-if [ $zonecount_temp > 0 ]; then
+if [ $zonecount_temp -gt 0 ]; then
 	zonecount=$zonecount_temp
 fi
 


### PR DESCRIPTION
Summary: Fixes script mistakenly creating a file named "0".  

This conditional was intended to check for a value greater than 0, but mistakenly redirects output to a file named 0 due to syntax.