### PR TITLE
Update client.cpp: remove variable redefinitions

### DIFF
--- a/loginserver/client.cpp
+++ b/loginserver/client.cpp
@@ -251,8 +251,8 @@ void Client::Handle_Login(const char* data, unsigned int size, std::string clien
 		//Get rid of that 989 studios part of the string, plus remove null term zero.
 		string userpass = ourdata.substr(0, ourdata.find("eqworld-52.989studios.com") - 1);
 
-		string username = userpass.substr(0, userpass.find("/"));
-		string password = userpass.substr(userpass.find("/") + 1);
+		username = userpass.substr(0, userpass.find("/"));
+		password = userpass.substr(userpass.find("/") + 1);
 		platform = "OSX";
 		macversion = intel;
 	}


### PR DESCRIPTION
Fixes MacOS Client support.  The username and password variables were previously defined at L211 and L212 respectively.  Without this fix, the username value is blank after leaving local scope of the conditional where its set (for OSX clients).  This was causing a blank username string to get passed to the Client::Handle_Login function.  When this happens, attempts by Macintosh clients to connect to the server fail.

This patch is how I was able to fix Mac support on EQA server.  I discussed this fix with Solar in discord.