### PR TITLE
Fixing /decline for duels

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
 	"editor.insertSpaces": false,
 	"editor.tabSize": 4,
 	"editor.autoIndent": "full",
-	"editor.trimAutoWhitespace": true,
-	"files.trimTrailingWhitespace": true,
+	"editor.trimAutoWhitespace": false,
+	"files.trimTrailingWhitespace": false,
 	//"editor.formatOnSave": true,
 	"search.exclude": {
 		"dependencies": false,

--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -73,9 +73,9 @@ struct Duel_Struct
 
 struct DuelResponse_Struct
 {
-	uint32 target_id;
-	uint32 entity_id;
-	uint32 unknown;
+	uint16 duel_initiator;
+	uint16 duel_target;
+	uint16 unknown;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3798,9 +3798,8 @@ void Client::Handle_OP_DuelResponse(const EQApplicationPacket *app)
 	if (app->size != sizeof(DuelResponse_Struct))
 		return;
 	DuelResponse_Struct* ds = (DuelResponse_Struct*)app->pBuffer;
-	Entity* entity = entity_list.GetID(ds->target_id);
-	Entity* initiator = entity_list.GetID(ds->entity_id);
-	
+	Entity* entity = entity_list.GetID(ds->duel_target);
+	Entity* initiator = entity_list.GetID(ds->duel_initiator);
 	if(!entity || !initiator)
 		return;
 	
@@ -3812,9 +3811,11 @@ void Client::Handle_OP_DuelResponse(const EQApplicationPacket *app)
 	initiator->CastToClient()->SetDuelTarget(0);
 	initiator->CastToClient()->SetDueling(false);
 	if (GetID() == initiator->GetID())
-		entity->CastToClient()->Message_StringID(CC_Default, DUEL_DECLINE, initiator->GetName());
+		// not sure how this would ever be true, because not even eqlive allows the initiator to /decline
+		entity->CastToClient()->Message_StringID(CC_Default, DUEL_DECLINE, initiator->CastToClient()->GetName());
 	else
-		initiator->CastToClient()->Message_StringID(CC_Default, DUEL_DECLINE, entity->GetName());
+		// inform initiator the duel was declined (the client handles informing the decliner)
+		initiator->CastToClient()->Message_StringID(CC_Default, DUEL_DECLINE, GetName());
 	return;
 }
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3810,12 +3810,8 @@ void Client::Handle_OP_DuelResponse(const EQApplicationPacket *app)
 	entity->CastToClient()->SetDueling(false);
 	initiator->CastToClient()->SetDuelTarget(0);
 	initiator->CastToClient()->SetDueling(false);
-	if (GetID() == initiator->GetID())
-		// not sure how this would ever be true, because not even eqlive allows the initiator to /decline
-		entity->CastToClient()->Message_StringID(CC_Default, DUEL_DECLINE, initiator->CastToClient()->GetName());
-	else
-		// inform initiator the duel was declined (the client handles informing the decliner)
-		initiator->CastToClient()->Message_StringID(CC_Default, DUEL_DECLINE, GetName());
+	// inform initiator the duel was declined (the client handles informing the decliner)
+	initiator->CastToClient()->Message_StringID(CC_Default, DUEL_DECLINE, GetName());
 	return;
 }
 


### PR DESCRIPTION
/decline

current takp
Char1 /duel (targeting Char2)
Char1 gets: you have challenged Char2 to duel
Char2 gets: Char1 has challenged you to duel
Char2 /decline
Char2 gets: you decline Char1's duel	
Char1 receives nothing and can no longer request duels or accept them

fixed
Char1 /duel (targeting Char2)
Char1 gets: you have challenged Char2 to duel
Char2 gets: Char1 has challenged you to duel
Char2 /decline
Char2 gets: you decline Char1's duel	
Char1 gets: Char2 has declined your challenge
Char1 can now re-request duels without zoning