### PR TITLE
loginserver: bind to local address too

### DIFF
--- a/loginserver/server_manager.cpp
+++ b/loginserver/server_manager.cpp
@@ -229,7 +229,7 @@ void ServerManager::SendOldUserToWorldRequest(const char* server_id, unsigned in
 	bool found = false;
 	while (iter != m_world_servers.end())
 	{
-		if ((*iter)->GetRemoteIP() == server_id)
+		if ((*iter)->GetRemoteIP() == server_id || (*iter)->GetLocalIP() == server_id)
 		{
 			auto outapp = new ServerPacket(ServerOP_UsertoWorldReq, sizeof(UsertoWorldRequest_Struct));
 			auto *r = (UsertoWorldRequest_Struct*)outapp->pBuffer;


### PR DESCRIPTION
This change allows connections from the lan. Makes it simpler for testing in certain networking configurations.

Not sure if it was intentional to disallow connections from the lan. If it was intentional, then feel free to close this pr. Additionally, this functionality could be gated behind a configuration parameter or db rule.

Might fix #50, though the issue there, as it is described, is different.