### PR TITLE
Fix zone crash bug in iteminfo command

### DIFF
--- a/zone/gm_commands/iteminfo.cpp
+++ b/zone/gm_commands/iteminfo.cpp
@@ -3,7 +3,10 @@
 void command_iteminfo(Client *c, const Seperator *sep)
 {
 	auto inst = c->GetInv()[EQ::invslot::slotCursor];
-	if (!inst) { c->Message(13, "Error: You need an item on your cursor for this command"); }
+	if (!inst) { 
+		c->Message(Chat::Red, "Error: You need an item on your cursor for this command");
+		return;
+	}
 	auto item = inst->GetItem();
 	if (!item)
 		c->Message(Chat::Red, "Error: You need an item on your cursor for this command");


### PR DESCRIPTION
This change fixes a zone crash that will occur if the `#iteminfo` command is used without an item on the user's cursor.  When there is no item on the cursor, `inst` becomes a `nullptr` and the next instruction results in a `nullptr` dereference which crashes the zone process.